### PR TITLE
feat: expose AI subtask generation

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,6 +4,7 @@ This roadmap tracks major features proposed for the project. Each section lists 
 
 ## AI Command Center
 - [x] Integrate an AI service to generate subtasks and suggestions.
+- [x] Surface subtask generation on the task dashboard.
 - [ ] Allow users to review and edit AI-proposed outcomes.
 
 ## Collaboration & Sync


### PR DESCRIPTION
## Summary
- add AI subtask generation button on task cards and selected-task view
- create helper to generate and append subtasks using OpenAI
- update roadmap to reflect dashboard subtask support

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58719e1408324b56a3c964b7683c6