### PR TITLE
feat: add AI outcome review helper and task reordering

### DIFF
--- a/src/features/aiCommandCenter.ts
+++ b/src/features/aiCommandCenter.ts
@@ -83,3 +83,16 @@ export async function summarizeTask(task: TaskLike): Promise<string> {
     return task.title;
   }
 }
+
+/**
+ * Allow callers to review and edit AI-proposed outcomes.
+ * The provided editor callback receives each suggestion and its index
+ * and should return the revised text. This is a groundwork helper for
+ * a future UI where users can tweak AI results before saving.
+ */
+export function reviewAiOutcomes(
+  suggestions: string[],
+  editor: (suggestion: string, index: number) => string,
+): string[] {
+  return suggestions.map((s, i) => editor(s, i));
+}

--- a/src/features/enhancedTaskManagement.ts
+++ b/src/features/enhancedTaskManagement.ts
@@ -8,3 +8,15 @@ const PRIORITY_ORDER: Record<Priority, number> = { P0: 0, P1: 1, P2: 2 };
 export function sortByPriority(tasks: Task[]): Task[] {
   return [...tasks].sort((a, b) => PRIORITY_ORDER[a.priority] - PRIORITY_ORDER[b.priority]);
 }
+
+/**
+ * Reorder a list of tasks by moving the task at `fromIndex` to `toIndex`.
+ * This utility provides a foundation for drag-and-drop interactions
+ * between columns and within the same column.
+ */
+export function reorderTasks(tasks: Task[], fromIndex: number, toIndex: number): Task[] {
+  const updated = [...tasks];
+  const [moved] = updated.splice(fromIndex, 1);
+  updated.splice(toIndex, 0, moved);
+  return updated;
+}


### PR DESCRIPTION
## Summary
- allow editing of AI-proposed outcomes through new `reviewAiOutcomes` helper
- add `reorderTasks` utility to support drag-and-drop task movements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58b2cdd0083249325c4b7a54b1dba