### PR TITLE
Default to GPT-5 for AI interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm i
 npm run dev
 ```
 
-Optionally set `VITE_OPENAI_API_KEY` (and `VITE_OPENAI_MODEL`, default `gpt-4o-mini`) to enable AI-powered subtasks and the planning chatbot. If you have an AI Grants India key, supply it via `VITE_OPENAI_API_KEY`.
+Optionally set `VITE_OPENAI_API_KEY` (and `VITE_OPENAI_MODEL`, default `gpt-5`) to enable AI-powered subtasks and the planning chatbot. If you have an AI Grants India key, supply it via `VITE_OPENAI_API_KEY`.
 
 ## Features
 - Now / Next / Later / Backlog / Done

--- a/src/PlanningChatbot.tsx
+++ b/src/PlanningChatbot.tsx
@@ -88,7 +88,7 @@ export default function PlanningChatbot() {
           Authorization: `Bearer ${(import.meta as any).env?.VITE_OPENAI_API_KEY}`,
         },
         body: JSON.stringify({
-          model: (import.meta as any).env?.VITE_OPENAI_MODEL || "gpt-4o-mini",
+          model: (import.meta as any).env?.VITE_OPENAI_MODEL || "gpt-5",
           stream: true,
           messages: [systemMessage, ...messages, userMessage].map((m) => ({
             role: m.role,

--- a/src/features/aiCommandCenter.ts
+++ b/src/features/aiCommandCenter.ts
@@ -18,6 +18,11 @@ const API_KEY =
     | string
     | undefined;
 
+const MODEL =
+  ((import.meta as any).env?.VITE_OPENAI_MODEL ??
+    (globalThis as any)?.process?.env?.VITE_OPENAI_MODEL ??
+    "gpt-5") as string;
+
 export async function generateSubtasks(task: TaskLike): Promise<string[]> {
   if (!API_KEY) {
     console.warn("VITE_OPENAI_API_KEY not set; returning no subtasks.");
@@ -34,7 +39,7 @@ export async function generateSubtasks(task: TaskLike): Promise<string[]> {
         Authorization: `Bearer ${API_KEY}`,
       },
       body: JSON.stringify({
-        model: "gpt-3.5-turbo",
+        model: MODEL,
         messages: [{ role: "user", content: prompt }],
         temperature: 0.2,
       }),
@@ -73,7 +78,7 @@ export async function summarizeTask(task: TaskLike): Promise<string> {
         Authorization: `Bearer ${API_KEY}`,
       },
       body: JSON.stringify({
-        model: "gpt-3.5-turbo",
+        model: MODEL,
         messages: [{ role: "user", content: prompt }],
         temperature: 0.2,
         max_tokens: 50,


### PR DESCRIPTION
## Summary
- default the planning chatbot and AI command helpers to `gpt-5`
- allow aiCommandCenter to respect `VITE_OPENAI_MODEL`
- document the new default model

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a96fe989808324a24a59d0b97b5752