### PR TITLE
chore: use gpt-4.1-mini as default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm i
 npm run dev
 ```
 
-Optionally set `VITE_OPENAI_API_KEY` (and `VITE_OPENAI_MODEL`, default `gpt-5`) to enable AI-powered subtasks and the planning chatbot. If you have an AI Grants India key, supply it via `VITE_OPENAI_API_KEY`.
+Optionally set `VITE_OPENAI_API_KEY` (and `VITE_OPENAI_MODEL`, default `gpt-4.1-mini`) to enable AI-powered subtasks and the planning chatbot. If you have an AI Grants India key, supply it via `VITE_OPENAI_API_KEY`.
 
 ## Features
 - Now / Next / Later / Backlog / Done

--- a/src/PlanningChatbot.tsx
+++ b/src/PlanningChatbot.tsx
@@ -88,7 +88,7 @@ export default function PlanningChatbot() {
           Authorization: `Bearer ${(import.meta as any).env?.VITE_OPENAI_API_KEY}`,
         },
         body: JSON.stringify({
-          model: (import.meta as any).env?.VITE_OPENAI_MODEL || "gpt-5",
+          model: (import.meta as any).env?.VITE_OPENAI_MODEL || "gpt-4.1-mini",
           stream: true,
           messages: [systemMessage, ...messages, userMessage].map((m) => ({
             role: m.role,

--- a/src/features/aiCommandCenter.ts
+++ b/src/features/aiCommandCenter.ts
@@ -21,7 +21,7 @@ const API_KEY =
 const MODEL =
   ((import.meta as any).env?.VITE_OPENAI_MODEL ??
     (globalThis as any)?.process?.env?.VITE_OPENAI_MODEL ??
-    "gpt-5") as string;
+    "gpt-4.1-mini") as string;
 
 export async function generateSubtasks(task: TaskLike): Promise<string[]> {
   if (!API_KEY) {


### PR DESCRIPTION
## Summary
- default to `gpt-4.1-mini` for OpenAI-powered helpers
- document the new default model

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a97586088c83249e5f95496237fdce