### PR TITLE
Fix core studio features: offline mode, calendar timezone, AI subtask feedback

### DIFF
--- a/src/FocusStudioStarter.tsx
+++ b/src/FocusStudioStarter.tsx
@@ -24,7 +24,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { sortByPriority } from "@/features/enhancedTaskManagement";
 import { computeStats } from "@/features/analyticsReporting";
-import { generateSubtasks } from "@/features/aiCommandCenter";
+import { generateSubtasks, hasOpenAiKey } from "@/features/aiCommandCenter";
 import {
   DndContext,
   DragEndEvent,
@@ -73,6 +73,7 @@ import TimeReport from "@/components/TimeReport";
 import { AssigneePicker } from "@/components/AssigneePicker";
 import { useWorkspace } from "@/lib/workspaceContext";
 import { newUuid as uid } from "@/lib/utils";
+import { parseDueDate } from "@/lib/calendarUtils";
 
 // ------------------------------------------------------------
 // AI Consulting Studio: Local task & project manager
@@ -280,7 +281,7 @@ function TaskCard({ task, onUpdate, onMove, onGenerateSubtasks, onSelect }: {
                 ))}
                 {task.due ? (
                   <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] bg-amber-500/10 text-amber-600 dark:text-amber-400">
-                    <Calendar className="h-2.5 w-2.5" />{new Date(task.due).toLocaleDateString()}
+                    <Calendar className="h-2.5 w-2.5" />{parseDueDate(task.due).toLocaleDateString()}
                   </span>
                 ) : null}
               </div>
@@ -371,6 +372,7 @@ export default function FocusStudioStarter() {
   const [notesOpen, setNotesOpen] = useState(false);
   const [notesDraft, setNotesDraft] = useState("");
   const [subtaskLoading, setSubtaskLoading] = useState(false);
+  const [subtaskMsg, setSubtaskMsg] = useState<string | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
   const [timeReportOpen, setTimeReportOpen] = useState(false);
 
@@ -411,6 +413,7 @@ export default function FocusStudioStarter() {
   // Sync edit fields when selected task changes
   const selectedTask = useMemo(() => tasks.find((t) => t.id === selectedTaskId) || null, [tasks, selectedTaskId]);
   useEffect(() => {
+    setSubtaskMsg(null);
     if (selectedTask) {
       setEditTitle(selectedTask.title);
       setEditPriority(selectedTask.priority);
@@ -456,7 +459,13 @@ export default function FocusStudioStarter() {
 
   const generateSubtasksFor = async (task: Task) => {
     setSubtaskLoading(true);
-    const subs = await generateSubtasks({ title: task.title, notes: task.notes });
+    setSubtaskMsg(null);
+    let subs: string[] = [];
+    try {
+      subs = await generateSubtasks({ title: task.title, notes: task.notes });
+    } catch {
+      subs = [];
+    }
     setSubtaskLoading(false);
     if (subs.length) {
       const newTasks = subs.map((title) => ({
@@ -468,6 +477,15 @@ export default function FocusStudioStarter() {
         completed: false,
       }));
       setTasks((prev) => [...prev, ...newTasks]);
+      setSubtaskMsg(
+        `Added ${newTasks.length} subtask${newTasks.length === 1 ? "" : "s"} to ${COLUMN_CONFIG[task.status].label}.`,
+      );
+    } else {
+      setSubtaskMsg(
+        hasOpenAiKey()
+          ? "The AI didn't return any subtasks. Try a more descriptive task title."
+          : "AI subtasks need an OpenAI API key. Set VITE_OPENAI_API_KEY to enable this feature.",
+      );
     }
   };
 
@@ -803,6 +821,11 @@ export default function FocusStudioStarter() {
                             <Sparkles className="h-3.5 w-3.5 mr-1" />{subtaskLoading ? "Generating..." : "AI Subtasks"}
                           </Button>
                         </div>
+                        {subtaskMsg && (
+                          <div className="text-xs text-muted-foreground bg-muted/30 border border-border rounded-lg px-3 py-2">
+                            {subtaskMsg}
+                          </div>
+                        )}
                       </div>
                     ) : (
                       <div className="text-center py-8">
@@ -923,8 +946,8 @@ export default function FocusStudioStarter() {
                     <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider mb-1 block">Due Date</label>
                     <Input
                       type="date"
-                      value={editDue ? editDue.split("T")[0] : ""}
-                      onChange={(e) => setEditDue(e.target.value ? new Date(e.target.value).toISOString() : "")}
+                      value={editDue ? editDue.slice(0, 10) : ""}
+                      onChange={(e) => setEditDue(e.target.value)}
                       className="h-9 text-xs"
                     />
                   </div>
@@ -1004,6 +1027,12 @@ export default function FocusStudioStarter() {
                     </Button>
                   </div>
                 </div>
+
+                {subtaskMsg && (
+                  <div className="text-xs text-muted-foreground bg-muted/40 border border-border rounded-lg px-3 py-2">
+                    {subtaskMsg}
+                  </div>
+                )}
               </div>
             )}
           </DialogContent>

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -17,6 +17,7 @@ import {
   formatDayHeader,
   groupTasksByDate,
   toDateKey,
+  parseDueDate,
 } from "@/lib/calendarUtils";
 
 export interface CalendarViewProps {
@@ -110,7 +111,7 @@ export default function CalendarView({
   const overdueSet = useMemo(() => {
     const set = new Set<string>();
     for (const task of tasks) {
-      if (task.due && !task.completed && isPast(new Date(task.due))) {
+      if (task.due && !task.completed && isPast(parseDueDate(task.due))) {
         set.add(task.id);
       }
     }

--- a/src/components/TeamTaskView.tsx
+++ b/src/components/TeamTaskView.tsx
@@ -16,6 +16,7 @@ import { useAuth } from "@/lib/authContext";
 import { useWorkspace } from "@/lib/workspaceContext";
 import { useProjects } from "@/lib/projectContext";
 import type { Task, ColumnKey } from "@/FocusStudioStarter";
+import { parseDueDate } from "@/lib/calendarUtils";
 import {
   Users,
   Search,
@@ -611,7 +612,7 @@ export function TeamTaskView({ onOpenTask }: TeamTaskViewProps) {
                           <span>·</span>
                           <span className="inline-flex items-center gap-0.5">
                             <Clock className="h-2.5 w-2.5" />
-                            {new Date(t.due).toLocaleDateString()}
+                            {parseDueDate(t.due).toLocaleDateString()}
                           </span>
                         </>
                       )}

--- a/src/features/aiCommandCenter.ts
+++ b/src/features/aiCommandCenter.ts
@@ -23,6 +23,12 @@ const MODEL =
     (globalThis as any)?.process?.env?.VITE_OPENAI_MODEL ??
     "gpt-4.1-mini") as string;
 
+/** Whether an OpenAI API key is configured — lets the UI explain why AI
+ * features are unavailable instead of silently doing nothing. */
+export function hasOpenAiKey(): boolean {
+  return Boolean(API_KEY);
+}
+
 export async function generateSubtasks(task: TaskLike): Promise<string[]> {
   if (!API_KEY) {
     console.warn("VITE_OPENAI_API_KEY not set; returning no subtasks.");

--- a/src/features/mobileOffline.ts
+++ b/src/features/mobileOffline.ts
@@ -2,9 +2,9 @@
 // TODO: implement service worker registration and PWA support.
 
 export function registerServiceWorker() {
-  if (typeof navigator !== "undefined" && "serviceWorker" in navigator) {
-    navigator.serviceWorker.register("/sw.js").catch((err) => {
-      console.error("Service worker registration failed", err);
-    });
-  }
+  // No service worker ships with the app yet. Attempting to register a
+  // non-existent "/sw.js" throws a 404 + SecurityError in the console on
+  // every page load, so this is intentionally a no-op until a real service
+  // worker is added. When implementing PWA support, register the worker here
+  // and ship the corresponding sw.js in the build output.
 }

--- a/src/lib/calendarUtils.ts
+++ b/src/lib/calendarUtils.ts
@@ -1,6 +1,23 @@
 import type { Task } from "@/FocusStudioStarter";
 
 /**
+ * Parse a task due value into a LOCAL-time Date at midnight.
+ *
+ * Due values are stored as calendar dates. A bare "YYYY-MM-DD" (and the
+ * date portion of any ISO string) is interpreted in the user's local
+ * timezone — `new Date("2026-07-24")` would otherwise parse as UTC
+ * midnight and render on the previous day for users west of UTC, dropping
+ * tasks into the wrong calendar cell.
+ */
+export function parseDueDate(due: string): Date {
+  const datePart = due.slice(0, 10);
+  const [y, m, d] = datePart.split("-").map(Number);
+  if (y && m && d) return new Date(y, m - 1, d);
+  // Fallback for unexpected formats — better than throwing.
+  return new Date(due);
+}
+
+/**
  * Returns an array of 7 dates (Mon–Sun) for the week containing the given reference date.
  */
 export function getWeekDays(referenceDate: Date): Date[] {
@@ -88,7 +105,7 @@ export function groupTasksByDate(
       continue;
     }
 
-    const taskDate = new Date(task.due);
+    const taskDate = parseDueDate(task.due);
     const key = toDateKey(taskDate);
     const bucket = map.get(key);
     if (bucket) {
@@ -115,7 +132,7 @@ export function groupTasksByDate(
 export function getOverdueTasks(tasks: Task[]): Task[] {
   return tasks.filter((t) => {
     if (!t.due || t.completed) return false;
-    return isPast(new Date(t.due));
+    return isPast(parseDueDate(t.due));
   });
 }
 

--- a/src/lib/workspaceContext.tsx
+++ b/src/lib/workspaceContext.tsx
@@ -13,7 +13,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { supabase, db } from "@/lib/supabase";
+import { supabase, db, isSupabaseConfigured } from "@/lib/supabase";
 import { useAuth } from "@/lib/authContext";
 import type {
   Workspace,
@@ -27,6 +27,30 @@ import type {
 
 const ACTIVE_WORKSPACE_KEY = "acs_active_workspace_v1";
 const ACTIVE_TEAM_KEY = "acs_active_team_v1";
+
+// When Supabase isn't configured the app runs in single-user, localStorage-only
+// mode. There is no backend to load workspaces/teams from, so we synthesize a
+// local workspace + team. Without this `currentWorkspace` stays null and the
+// app shell blocks every view with "No workspace selected".
+const OFFLINE = !isSupabaseConfigured();
+
+const LOCAL_WORKSPACE: Workspace = {
+  id: "local",
+  name: "Local Workspace",
+  slug: "local",
+  createdBy: "local",
+  createdAt: new Date(0).toISOString(),
+};
+
+const LOCAL_TEAM: Team = {
+  id: "local-team",
+  workspaceId: LOCAL_WORKSPACE.id,
+  name: "My Team",
+  description: undefined,
+  color: undefined,
+  createdBy: undefined,
+  createdAt: new Date(0).toISOString(),
+};
 
 // ---- DB row mappings ----
 
@@ -134,11 +158,15 @@ const WorkspaceContext = createContext<WorkspaceContextValue | undefined>(undefi
 export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
 
-  const [loading, setLoading] = useState(true);
-  const [workspaces, setWorkspaces] = useState<Workspace[]>([]);
-  const [currentWorkspaceId, setCurrentWorkspaceId] = useState<string | null>(null);
-  const [teams, setTeams] = useState<Team[]>([]);
-  const [currentTeamId, setCurrentTeamId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(!OFFLINE);
+  const [workspaces, setWorkspaces] = useState<Workspace[]>(OFFLINE ? [LOCAL_WORKSPACE] : []);
+  const [currentWorkspaceId, setCurrentWorkspaceId] = useState<string | null>(
+    OFFLINE ? LOCAL_WORKSPACE.id : null,
+  );
+  const [teams, setTeams] = useState<Team[]>(OFFLINE ? [LOCAL_TEAM] : []);
+  const [currentTeamId, setCurrentTeamId] = useState<string | null>(
+    OFFLINE ? LOCAL_TEAM.id : null,
+  );
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [teamMembers, setTeamMembers] = useState<TeamMember[]>([]);
   const [profiles, setProfiles] = useState<Record<string, Profile>>({});
@@ -146,6 +174,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
 
   // Hydrate persisted selections
   useEffect(() => {
+    if (OFFLINE) return; // offline uses the fixed local workspace/team
     try {
       const w = localStorage.getItem(ACTIVE_WORKSPACE_KEY);
       const t = localStorage.getItem(ACTIVE_TEAM_KEY);
@@ -157,6 +186,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (OFFLINE) return;
     if (currentWorkspaceId) {
       try {
         localStorage.setItem(ACTIVE_WORKSPACE_KEY, JSON.stringify(currentWorkspaceId));
@@ -167,6 +197,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   }, [currentWorkspaceId]);
 
   useEffect(() => {
+    if (OFFLINE) return;
     if (currentTeamId) {
       try {
         localStorage.setItem(ACTIVE_TEAM_KEY, JSON.stringify(currentTeamId));
@@ -280,6 +311,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
 
   // Load workspace-scoped data when current workspace changes
   useEffect(() => {
+    if (OFFLINE) return; // no backend to load teams/members/profiles from
     if (!currentWorkspaceId) {
       setTeams([]);
       setMembers([]);


### PR DESCRIPTION
## Summary

Audited and fixed the five headline features so they work in the default zero-config (`npm run dev`, no Supabase) setup, verified each in a headless browser.

- **Brain-dump your day → AI turns it into tasks**
- **AI Subtasks breaks any task into steps**
- **Now / Next / Later board + weekly calendar**
- **Focus mode with Pomodoro timer + time tracking**
- **Live team view**

## What was broken

**1. Offline mode blocked everything (critical).** Without Supabase configured, no user ever loads, so `WorkspaceProvider` never resolved a workspace — and the app shell gated *every* view behind "No workspace selected." All five features were unreachable in the documented default setup. Fix: synthesize a local workspace + team when Supabase isn't configured, and guard the backend-touching effects (which would also dereference the null `db` client).

**2. Calendar placed tasks on the wrong day (timezone bug).** Due dates are stored as calendar dates, but `new Date("2026-07-24")` parses as UTC midnight — so for users west of UTC the calendar grouped, flagged overdue, and displayed tasks one day early. Fix: a `parseDueDate()` helper that reads the date in local time, used consistently in grouping, overdue detection, and every display site; the edit dialog now stores date-only strings.

**3. AI Subtasks failed silently.** With no API key (or an empty result) the button spun and reverted with zero feedback. Fix: a clear message ("set `VITE_OPENAI_API_KEY`" / "added N subtasks" / "none returned") in both the task dialog and focus-mode card, plus try/catch hardening.

**4. Service-worker 404 noise.** `registerServiceWorker()` pointed at a non-existent `/sw.js`, throwing a 404 + SecurityError on every load. Made it a no-op until a real worker ships.

## Changes

| File | Change |
|------|--------|
| `src/lib/workspaceContext.tsx` | Synthesize local workspace/team offline; guard Supabase-only effects |
| `src/lib/calendarUtils.ts` | Add `parseDueDate()` (local-time); use in grouping + overdue |
| `src/components/CalendarView.tsx` | Use `parseDueDate()` for overdue detection |
| `src/components/TeamTaskView.tsx` | Use `parseDueDate()` for due-date display |
| `src/FocusStudioStarter.tsx` | AI-subtask feedback messages; local-time due display; date-only edit dialog |
| `src/features/aiCommandCenter.ts` | Export `hasOpenAiKey()` for accurate UI messaging |
| `src/features/mobileOffline.ts` | No-op service-worker registration (removes 404 noise) |

## Verification

- Production `npm run build` passes.
- Headless-browser pass over all five features (offline mode): **22/22 checks passed**, console clean apart from a harmless favicon 404.
- Timezone check confirms due dates land on the correct calendar day in UTC, US Pacific, and IST (old code placed them a day early in US Pacific).

## Note (not changed — out of scope)

The app-shell header and the board's own header are both `sticky top-0`, so they visually overlap when scrolled. It's cosmetic and pre-existing (doesn't block any feature), so it was left as-is to avoid a global layout regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gPnAHheesEBffCchwc2YN

---
_Generated by [Claude Code](https://claude.ai/code/session_016gPnAHheesEBffCchwc2YN)_